### PR TITLE
Move OIDC endpoints to root level

### DIFF
--- a/internal/interfaces/http/router.go
+++ b/internal/interfaces/http/router.go
@@ -107,6 +107,12 @@ func NewRouter(
 		http.ServeFile(w, r, "docs/swagger.json")
 	})
 
+	// OIDC routes
+	router.Group(func(r chi.Router) {
+		r.Get("/.well-known/openid-configuration", oidcHandler.GetOpenIDConfigurationHandler)
+		r.Get("/.well-known/jwks.json", oidcHandler.GetJWKSHandler)
+	})
+
 	// API routes without version in URL
 	router.Route("/api", func(r chi.Router) {
 		// Public routes
@@ -117,12 +123,6 @@ func NewRouter(
 			r.Post("/auth/verify-email", authHandler.VerifyEmailHandler)
 			r.Post("/auth/request-password-reset", authHandler.RequestPasswordResetHandler)
 			r.Post("/auth/reset-password", authHandler.ResetPasswordHandler)
-		})
-
-		// OIDC routes
-		r.Group(func(r chi.Router) {
-			r.Get("/.well-known/openid-configuration", oidcHandler.GetOpenIDConfigurationHandler)
-			r.Get("/.well-known/jwks.json", oidcHandler.GetJWKSHandler)
 		})
 
 		// Admin routes


### PR DESCRIPTION
The OIDC discovery endpoints (`/.well-known/openid-configuration` and `/.well-known/jwks.json`) have been moved from the `/api` prefix to the root level of the router. This aligns with standard OIDC practices.